### PR TITLE
chore(license): relicense under AGPL-3.0-or-later, add CLA and notices

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,65 @@
+# Requires every outside contributor to sign the Contributor License Agreement
+# (CLA.md) before their pull request can be merged.
+#
+# Why: Electra.Academy is dual-licensed (AGPL + commercial, see
+# COMMERCIAL-LICENSE.md). Selling a commercial license is only possible while
+# the rights to the combined work rest with one party. A single unsigned outside
+# patch would end that permanently.
+#
+# How it works: the action posts a comment on new pull requests. The contributor
+# signs by replying with the exact sentence quoted in CLA.md. The signature is
+# then appended to signatures/version1/cla.json IN THIS REPOSITORY, so there is
+# no external service and no third party holding the records. Once signed, all
+# future pull requests by that person pass automatically.
+#
+# ONE MANUAL STEP REMAINS: make "CLA Assistant" a required status check under
+# Settings -> Branches -> branch protection for the default branch. Without
+# that, the check reports failure but does not actually block merging.
+#
+# Note on pull_request_target: this trigger runs the workflow from the BASE
+# branch with a token that can write, which is what lets the action record a
+# signature from a fork. It deliberately does not check out the PR head, so
+# untrusted code is never executed here. Do not add a checkout of the PR head.
+
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: "signatures/version1/cla.json"
+          path-to-document: "https://github.com/freegroup/electra/blob/main/CLA.md"
+          branch: "main"
+          # The project owner does not sign their own CLA, and dependency bots
+          # contribute no copyrightable work.
+          allowlist: freegroup,dependabot[bot],renovate[bot],github-actions[bot]
+          custom-notsigned-prcomment: |
+            Thanks for the pull request!
+
+            Electra.Academy is dual-licensed: AGPL for everyone, plus a
+            commercial license that funds keeping it free for schools. That
+            second license only works while the rights to the whole work rest
+            with one party, so outside contributions need a signed CLA.
+
+            Please read **[CLA.md](https://github.com/freegroup/electra/blob/main/CLA.md)**
+            and, if you agree, post a comment on this pull request with exactly:
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: "CLA signed by all contributors. Thanks - ready for review."

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,249 @@
+# Contributor License Agreement (CLA)
+
+**Electra.Academy**
+Version 1.0
+
+Die deutsche Fassung ist verbindlich. An English translation follows below for
+convenience; in case of conflict the German text prevails.
+
+> **Hinweis:** Dieses Dokument ist von einem Entwickler verfasst, nicht von
+> einem Anwalt, und stellt keine Rechtsberatung dar. Vor der ersten kommerziellen
+> Verwertung auf Basis dieser CLA sollte sie anwaltlich geprüft werden.
+
+---
+
+## Deutsche Fassung
+
+### 1. Worum es geht
+
+Electra.Academy wird unter der AGPL-3.0-or-later veröffentlicht und zusätzlich
+kommerziell lizenziert (siehe [`COMMERCIAL-LICENSE.md`](./COMMERCIAL-LICENSE.md)).
+Die Einnahmen daraus finanzieren die Arbeit, die das Projekt für Schulen
+kostenlos hält.
+
+Eine zweite Lizenz kann nur vergeben werden, wenn die Rechte am Gesamtwerk in
+einer Hand liegen. Ohne diese Vereinbarung könnte schon ein einzelner fremder
+Beitrag die kommerzielle Lizenzierung dauerhaft unmöglich machen - auch für den
+Projektinhaber selbst.
+
+### 2. Begriffe
+
+- **Rechteinhaber** ist Andreas Herz, a.herz@freegroup.de.
+- **Beitrag** ist jedes Werk, das Du dem Projekt zur Aufnahme übermittelst -
+  Quellcode, Dokumentation, Übersetzungen, Grafiken, Unterrichtsmaterial,
+  Konfiguration.
+- **Du** bist die natürliche oder juristische Person, die den Beitrag einreicht.
+
+### 3. Einräumung von Nutzungsrechten
+
+Da das Urheberrecht nach § 29 Abs. 1 UrhG nicht übertragbar ist, wird kein
+Urheberrecht abgetreten. Stattdessen räumst Du dem Rechteinhaber an Deinem
+Beitrag das **ausschließliche Nutzungsrecht** nach § 31 UrhG ein:
+
+- räumlich, zeitlich und inhaltlich unbeschränkt,
+- für alle bekannten Nutzungsarten,
+- **übertragbar** auf Dritte, auch im Rahmen einer Unternehmens- oder
+  Projektübertragung,
+- **unterlizenzierbar**, einschließlich des Rechts, den Beitrag unter
+  beliebigen Lizenzbedingungen weiterzugeben - insbesondere unter der AGPL
+  **und** unter kommerziellen, nicht-copyleft Bedingungen,
+- einschließlich des Rechts zur Bearbeitung, Umgestaltung und Verbindung mit
+  anderen Werken.
+
+### 3a. Recht zum Lizenzwechsel
+
+Ausdrücklich eingeschlossen ist das Recht des Rechteinhabers, **die Lizenz des
+Projekts jederzeit und ohne erneute Zustimmung der Beitragenden zu ändern** -
+auch auf eine Lizenz mit anderen Bedingungen als der AGPL. Du erteilst Deine
+Zustimmung zu einem solchen Lizenzwechsel bereits mit dieser Vereinbarung im
+Voraus.
+
+Das ist der eigentliche Zweck dieser CLA: ohne sie müsste bei jedem
+Lizenzwechsel jeder einzelne Beitragende erneut gefragt werden, und ein einziger
+nicht erreichbarer oder widersprechender Beitragender würde den Wechsel
+dauerhaft blockieren.
+
+Zwei Grenzen dieses Rechts, die auch mit CLA bestehen:
+
+- Ein Lizenzwechsel wirkt nur **für die Zukunft**. Bereits unter der AGPL
+  veröffentlichte Fassungen bleiben für alle unter der AGPL nutzbar; eine
+  erteilte Lizenz kann nicht zurückgerufen werden.
+- Für heute noch **unbekannte Nutzungsarten** verlangt § 31a UrhG die
+  Schriftform. Eine elektronisch erteilte CLA deckt diese daher möglicherweise
+  nicht ab. Ein Wechsel auf eine andere Softwarelizenz ist davon nicht
+  betroffen, weil es sich um eine bekannte Nutzungsart handelt.
+
+### 4. Was Du behältst
+
+Du bleibst Urheber Deines Beitrags. Insbesondere:
+
+- Deine **Urheberpersönlichkeitsrechte** bleiben unberührt; sie sind nach
+  deutschem Recht ohnehin nicht übertragbar.
+- Du behältst ein **einfaches, nicht ausschließliches, unentgeltliches und
+  unwiderrufliches Nutzungsrecht** an Deinem eigenen Beitrag. Du darfst ihn
+  also weiterhin selbst verwenden, in anderen Projekten einsetzen und
+  veröffentlichen. Diese Vereinbarung nimmt Dir Deinen eigenen Code nicht weg.
+- Dein Beitrag bleibt für die Allgemeinheit unter der AGPL verfügbar. Das kann
+  nicht zurückgenommen werden.
+- Deine Nennung erfolgt über die Git-Historie.
+
+### 5. Deine Zusicherungen
+
+Du sicherst zu, dass
+
+- Du den Beitrag selbst erstellt hast und über die eingeräumten Rechte verfügen
+  kannst,
+- der Beitrag keine Rechte Dritter verletzt, insbesondere keine fremden
+  Urheber-, Marken- oder Patentrechte,
+- Du, sofern Du den Beitrag im Rahmen eines Arbeits- oder Auftragsverhältnisses
+  erstellt hast, die erforderliche Zustimmung Deines Arbeitgebers oder
+  Auftraggebers eingeholt hast,
+- Du auf fremde Bestandteile im Beitrag samt deren Lizenz hinweist.
+
+### 6. Kein Anspruch auf Aufnahme, keine Gegenleistung
+
+Der Rechteinhaber ist nicht verpflichtet, einen Beitrag aufzunehmen oder zu
+pflegen. Für den Beitrag wird keine Vergütung geschuldet.
+
+### 7. Haftung
+
+Der Beitrag wird ohne Gewähr bereitgestellt. Eine Haftung für Sachmängel und
+Rechtsmängel wird ausgeschlossen, soweit gesetzlich zulässig. Unberührt bleibt
+die Haftung für Vorsatz, Arglist und grobe Fahrlässigkeit sowie für Schäden aus
+der Verletzung des Lebens, des Körpers oder der Gesundheit.
+
+### 8. Schlussbestimmungen
+
+Es gilt deutsches Recht. Sollte eine Bestimmung unwirksam sein, bleibt die
+Vereinbarung im Übrigen wirksam.
+
+### 9. Wie Du unterschreibst
+
+Du unterzeichnest, indem Du in Deinem Pull Request einen Kommentar mit genau
+diesem Satz hinterlässt:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Deine Signatur wird mit GitHub-Benutzername, Pull-Request-Nummer und Zeitstempel
+in `signatures/version1/cla.json` in diesem Repository festgehalten. Einmal
+unterzeichnet, gilt die CLA für alle Deine künftigen Beiträge zu diesem Projekt.
+
+Wenn Du diese Bedingungen nicht akzeptieren möchtest: ein Issue, ein Bugreport
+oder ein Reproduktionsfall ist auch ohne CLA wertvoll und willkommen.
+
+---
+
+## English translation
+
+### 1. Purpose
+
+Electra.Academy is published under AGPL-3.0-or-later and additionally licensed
+commercially (see [`COMMERCIAL-LICENSE.md`](./COMMERCIAL-LICENSE.md)). Revenue
+from that funds the work that keeps the project free for schools.
+
+A second license can only be granted if the rights to the combined work rest
+with one party. Without this agreement, a single outside contribution could
+permanently make commercial licensing impossible - even for the project owner.
+
+### 2. Definitions
+
+- **Rights holder** is Andreas Herz, a.herz@freegroup.de.
+- **Contribution** is any work you submit for inclusion: source code,
+  documentation, translations, artwork, teaching material, configuration.
+- **You** are the individual or legal entity submitting the contribution.
+
+### 3. Grant of rights
+
+Because German copyright law (§ 29(1) UrhG) does not permit the transfer of
+copyright itself, no copyright is assigned. Instead you grant the rights holder
+an **exclusive right of use** (§ 31 UrhG) in your contribution:
+
+- unlimited in territory, time and scope,
+- for all known types of use,
+- **transferable** to third parties, including as part of a transfer of the
+  business or the project,
+- **sublicensable**, including the right to distribute the contribution under
+  any license terms - in particular under the AGPL **and** under commercial,
+  non-copyleft terms,
+- including the right to modify, adapt and combine it with other works.
+
+### 3a. Right to change the license
+
+Expressly included is the rights holder's right to **change the project's
+license at any time without asking contributors again** - including to a license
+with terms other than the AGPL. By entering into this agreement you give your
+consent to such a license change in advance.
+
+This is the actual purpose of this CLA: without it, every license change would
+require asking each individual contributor again, and one unreachable or
+objecting contributor would block the change permanently.
+
+Two limits that remain even with a CLA:
+
+- A license change takes effect **going forward only**. Versions already
+  published under the AGPL remain usable by everyone under the AGPL; a license
+  once granted cannot be revoked.
+- For types of use that are **not yet known today**, § 31a UrhG requires written
+  form, which an electronically granted CLA may not satisfy. A change to another
+  software license is unaffected, as that is a known type of use.
+
+### 4. What you keep
+
+You remain the author of your contribution. Specifically:
+
+- Your **moral rights** are unaffected; under German law they are not
+  transferable in any case.
+- You retain a **non-exclusive, royalty-free, irrevocable right** to use your
+  own contribution. You may continue to use it yourself, in other projects, and
+  publish it. This agreement does not take your own code away from you.
+- Your contribution remains available to the public under the AGPL. That cannot
+  be revoked.
+- You are credited through the Git history.
+
+### 5. Your representations
+
+You represent that
+
+- you created the contribution yourself and are entitled to grant the rights
+  above,
+- the contribution does not infringe third-party rights, in particular
+  copyright, trademark or patent rights,
+- if you created the contribution in the course of employment or under
+  contract, you have obtained your employer's or client's consent,
+- you identify any third-party material in the contribution together with its
+  license.
+
+### 6. No obligation to accept, no compensation
+
+The rights holder is under no obligation to accept or maintain any
+contribution. No compensation is owed for a contribution.
+
+### 7. Liability
+
+The contribution is provided as is. Liability for defects in quality and title
+is excluded to the extent permitted by law. This does not affect liability for
+intent, fraudulent concealment, gross negligence, or for injury to life, body
+or health.
+
+### 8. Final provisions
+
+German law applies. If any provision is invalid, the remainder of this
+agreement stays in force.
+
+### 9. How to sign
+
+Sign by leaving a comment on your pull request containing exactly this
+sentence:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature is recorded with your GitHub username, the pull request number
+and a timestamp in `signatures/version1/cla.json` in this repository. Once
+signed, the CLA covers all your future contributions to this project.
+
+If you would rather not accept these terms: an issue, a bug report or a
+reproduction case is valuable and welcome without any CLA.

--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,47 @@
+# Commercial Licensing
+
+Electra.Academy is dual-licensed.
+
+## 1. The open source license - free for everyone
+
+By default the software is available under
+**AGPL-3.0-or-later** ([`LICENSE`](./LICENSE)). For schools, educational
+institutions, individuals and non-profit groups this is normally all you need,
+and it costs nothing. See [`LICENSING.md`](./LICENSING.md).
+
+The AGPL permits commercial use too. Its condition is that anyone who
+distributes the software, or operates a modified version as a network service,
+must make the complete corresponding source available under the same license
+(AGPL section 13).
+
+## 2. The commercial license - when copyleft does not work for you
+
+A separate, paid license is available for cases where the AGPL's obligations
+are not acceptable:
+
+- embedding Electra.Academy in a **proprietary product**
+- operating a **closed, hosted service** based on it without publishing your
+  modifications
+- redistribution under terms other than the AGPL
+- OEM or white-label arrangements
+
+This is possible because the entire project is authored by Andreas Herz, who
+holds the rights and can therefore grant terms in addition to the AGPL.
+Buying a commercial license does not take anything away from anyone: the AGPL
+version stays available to all, unchanged.
+
+## 3. Services - no license required
+
+Hosting, operation, maintenance, support, training and custom development are
+**services**, not a grant of rights. The AGPL does not restrict them and you do
+not need a commercial license to buy them. Offers for schools and school
+authorities (single school, district, state level) are available on request.
+
+## Contact
+
+Andreas Herz
+<a.herz@freegroup.de>
+
+Useful things to include in a first message: what you want to build or operate,
+whether it will be publicly reachable, whether you intend to modify the source,
+and the rough scale (number of schools, users, or installations).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,10 @@ directories - the very channels through which schools find it.
 ## Practical notes
 
 - Keep the style of the surrounding code; the project does not use a formatter.
-- Frontend changes need a rebuild of the affected app (`npm run build` in
-  `author`, `designer`, `gallery`, `home`, `legal` or `simulator`) - the bundles
-  under `public/js/webpack/` are checked in.
+- Frontend changes need a rebuild of the affected app: `npm run build` in
+  `author`, `designer`, `gallery`, `home`, `legal` or `simulator`. The generated
+  bundles under `public/js/webpack/` are gitignored, so do not commit them.
+  (`home/public/js/webpack/bundle.js` is tracked for historical reasons, from
+  before the ignore rule existed. Do not take it as the pattern.)
 - User-facing text belongs in `common/public/i18n/<app>/{de,en}.json`, never
   hardcoded in a template.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to Electra.Academy
+
+Contributions are welcome - bug reports, fixes, translations, teaching
+material, documentation.
+
+## Pull requests require a signed CLA
+
+Pull requests from outside contributors are welcome, but they need a signed
+**[Contributor License Agreement](./CLA.md)** before they can be merged.
+
+Signing takes one comment. When you open a pull request, a bot posts the
+instructions; you reply with the sentence quoted in [`CLA.md`](./CLA.md). Your
+signature is recorded in `signatures/version1/cla.json` in this repository - no
+external service is involved - and it covers all your future contributions.
+
+### Why
+
+Two reasons, and it is worth being straight about both:
+
+1. **The license may change.** Without a CLA, changing the project's license
+   later would require the agreement of every single contributor. One person who
+   has moved on, changed their email or simply says no would block it forever.
+   The CLA settles that consent up front.
+2. **Dual licensing pays for the free version.** Electra.Academy is AGPL for
+   everyone plus a commercial license for parties who cannot accept copyleft
+   (see [`COMMERCIAL-LICENSE.md`](./COMMERCIAL-LICENSE.md)). That second license
+   only works while the rights to the whole work rest with one party.
+
+### What it does not do
+
+You stay the author of your contribution. You keep a non-exclusive right to use
+your own code anywhere else, your moral rights are untouched, and your
+contribution stays available to everyone under the AGPL - that part cannot be
+revoked. The details are in [`CLA.md`](./CLA.md) §4.
+
+If you would rather not sign, that is fine: **issues, bug reports and
+reproduction cases need no CLA** and are genuinely useful on their own.
+
+## Sign-off (separate from the CLA)
+
+Please also sign off your commits:
+
+```
+git commit -s -m "your message"
+```
+
+This appends a `Signed-off-by:` line, certifying under the
+[Developer Certificate of Origin](https://developercertificate.org/) that you
+wrote the code or have the right to submit it.
+
+Note that the DCO and the CLA are **not** the same thing and neither replaces
+the other. The DCO certifies where the code came from; the CLA grants the rights
+needed to relicense it. We use both.
+
+## Third-party code
+
+Do not add third-party code to the tree without recording it in
+[`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md) with its version,
+license and copyright holder. Prefer an npm dependency over a vendored copy.
+
+Note that **NonCommercial licenses (CC BY-NC and similar) cannot be accepted**.
+They are not open source under the OSI definition, are incompatible with the
+AGPL, and would disqualify the project from public-sector software
+directories - the very channels through which schools find it.
+
+## Practical notes
+
+- Keep the style of the surrounding code; the project does not use a formatter.
+- Frontend changes need a rebuild of the affected app (`npm run build` in
+  `author`, `designer`, `gallery`, `home`, `legal` or `simulator`) - the bundles
+  under `public/js/webpack/` are checked in.
+- User-facing text belongs in `common/public/i18n/<app>/{de,en}.json`, never
+  hardcoded in a template.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,99 @@
+# Lizenzhinweis / Licensing Notice
+
+Dies ist die menschenlesbare Zusammenfassung. Verbindlich ist allein der
+Lizenztext in [`LICENSE`](./LICENSE).
+
+---
+
+## Kurzfassung
+
+**Electra.Academy steht unter der GNU Affero General Public License, Version 3
+oder später (AGPL-3.0-or-later).**
+
+### Kostenlos und ausdrücklich erwünscht
+
+Die Nutzung durch **Privatpersonen, Schulen, Bildungseinrichtungen,
+Hochschulen und gemeinnützige Arbeitsgruppen** ist kostenlos und ausdrücklich
+erwünscht. Du darfst die Software einsetzen, im Unterricht verwenden, auf
+eigenen Servern betreiben, anpassen und weitergeben.
+
+Es gibt dabei **keine Unterscheidung zwischen "kommerziell" und
+"nicht-kommerziell"**. Eine Schule mit Schulgeld, ein Bildungsträger mit
+kostenpflichtigen Kursen oder eine Behörde mit Gebührenhaushalt muss sich also
+nicht fragen, ob sie noch unter eine Ausnahme fällt. Sie darf.
+
+### Was die AGPL von dir verlangt
+
+Die AGPL ist eine Copyleft-Lizenz. Sie erlaubt kommerzielle Nutzung, stellt
+dafür aber Bedingungen:
+
+- Gibst du die Software oder eine abgewandelte Fassung weiter, muss der
+  vollständige Quellcode unter derselben Lizenz mitgeliefert werden.
+- **Betreibst du eine abgewandelte Fassung als Netzwerkdienst** (etwa als
+  gehostetes Angebot), musst du allen Nutzern dieses Dienstes den
+  vollständigen geänderten Quellcode zugänglich machen. Das ist §13 der AGPL
+  und der wesentliche Unterschied zur normalen GPL.
+- Urheber- und Lizenzhinweise müssen erhalten bleiben.
+
+Kurz gesagt: du darfst mit Electra.Academy Geld verdienen, aber du darfst es
+nicht schließen.
+
+### Wenn du diese Bedingungen nicht erfüllen willst
+
+Wer Electra.Academy in ein **proprietäres Produkt** einbauen oder als
+geschlossenen Dienst betreiben möchte, kann eine kommerzielle Lizenz erwerben,
+die von der Copyleft-Pflicht befreit. Siehe
+[`COMMERCIAL-LICENSE.md`](./COMMERCIAL-LICENSE.md).
+
+### Support, Hosting und Schulungen
+
+Dienstleistungen rund um die Software sind von der Lizenz **nicht** berührt.
+Betrieb, Wartung, Support, Schulungen und Anpassungen für Schulen und
+Schulträger werden unabhängig von den Nutzungsrechten angeboten. Anfragen an
+die unten genannte Adresse.
+
+---
+
+## Fremdkomponenten
+
+Nicht der gesamte Inhalt dieses Repositories steht unter der AGPL. Unter
+`common/public/js/` und `common/public/css/` liegen eingebundene
+Fremdbibliotheken (jQuery, Bootstrap, KaTeX und weitere) unter ihren eigenen,
+jeweils permissiven Lizenzen. Diese bleiben unverändert gültig und werden von
+der Lizenzierung dieses Projekts nicht berührt.
+
+Die vollständige Aufstellung steht in
+[`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md).
+
+---
+
+## Kontakt
+
+Urheber: Andreas Herz
+Kommerzielle Lizenzen, Support und Kooperationen: <a.herz@freegroup.de>
+
+---
+
+## English summary
+
+**Electra.Academy is licensed under the GNU Affero General Public License,
+version 3 or later (AGPL-3.0-or-later).**
+
+Use by individuals, schools, educational institutions and non-profit groups is
+free of charge and explicitly welcome. The AGPL draws no line between
+commercial and non-commercial use, so no school or public body has to assess
+whether it qualifies for an exemption.
+
+In exchange, the AGPL requires that anyone who distributes the software - or
+**operates a modified version as a network service** (AGPL section 13) - makes
+the complete corresponding source available under the same license.
+
+If you want to embed Electra.Academy in a proprietary product or run it as a
+closed service, a commercial license removing the copyleft obligation is
+available: see [`COMMERCIAL-LICENSE.md`](./COMMERCIAL-LICENSE.md).
+
+Services around the software - hosting, maintenance, support, training - are
+not restricted by the license and are offered separately.
+
+Third-party components under `common/public/js/` and `common/public/css/` keep
+their own licenses; see [`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Electra.Academy
 Circuits are better animated. Create, simulate, share, and explore electronic circuits!
 
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![Free for schools](https://img.shields.io/badge/Schools-free_to_use-brightgreen.svg)](./LICENSING.md)
+
 
 ## See It in Action
 When you make changes to your circuit design, Electra.Academy will show you animated simulations of how the logic changes are affecting your circuit. You'll be able to see exactly how your circuit is operating!
@@ -17,4 +20,36 @@ You can even adjust the circuit parameters while the simulation is running, and 
 Hosted on [https://electra.academy](https://electra.academy)
 
 ![overview](./electra.png)
+
+## License
+
+Electra.Academy is licensed under the **GNU Affero General Public License v3.0
+or later** (`AGPL-3.0-or-later`). The full text is in [`LICENSE`](./LICENSE).
+
+**Schools, educational institutions, individuals and non-profit groups: free to
+use, and explicitly welcome.** The AGPL makes no distinction between commercial
+and non-commercial use, so a school with tuition fees or a public body with a
+fee-funded budget does not have to work out whether it qualifies for an
+exemption. It does.
+
+In return, the AGPL requires that anyone distributing the software - or
+operating a modified version as a network service (AGPL section 13) - makes the
+complete corresponding source available under the same license. In short: you
+may earn money with Electra.Academy, but you may not close it.
+
+- Plain-language summary, German and English: [`LICENSING.md`](./LICENSING.md)
+- Proprietary or closed-service use: [`COMMERCIAL-LICENSE.md`](./COMMERCIAL-LICENSE.md)
+- Bundled third-party components and their licenses: [`THIRD-PARTY-NOTICES.md`](./THIRD-PARTY-NOTICES.md)
+
+### Support for schools
+
+Hosting, operation, maintenance, support and training are services and are not
+restricted by the license - no commercial license needed to buy them. Enquiries:
+<a.herz@freegroup.de>
+
+## Contributing
+
+Bug reports, fixes, translations and teaching material are welcome. Please read
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) first - it explains the license terms for
+contributions and why there is an additional copyright grant.
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,49 @@
+# Third-Party Notices
+
+Electra.Academy as a whole is licensed under AGPL-3.0-or-later (see
+[`LICENSE`](./LICENSE)). This file lists the third-party components that are
+**checked into this repository** and remain under their own licenses. Their
+terms are unaffected by the licensing of this project.
+
+Dependencies installed via npm are not listed here; their licenses ship with
+the packages in `node_modules/` and are declared in the respective
+`package-lock.json`.
+
+## License compatibility
+
+All components below are under permissive licenses (MIT, BSD, Apache-2.0) or
+are dual-licensed including a permissive option. Each of these is one-way
+compatible with AGPL-3.0: the combined work may be distributed under the AGPL,
+while the individual components keep their original terms. No component
+imposes a restriction that conflicts with the AGPL.
+
+## Components
+
+| Component | Version | License | Copyright | Location |
+|---|---|---|---|---|
+| jQuery | 1.12.4 | MIT | jQuery Foundation and contributors | `common/public/js/jquery/jquery.js` |
+| jQuery UI | 1.8.23 | MIT or GPL (dual) | jQuery Foundation and contributors (see AUTHORS.txt) | `common/public/js/jquery/jquery-ui.js` |
+| Bootstrap | 3.3.7 | MIT | 2011-2016 Twitter, Inc. | `common/public/js/bootstrap/` |
+| bootstrap-multiselect | - | Apache-2.0 | 2012-2015 David Stutz | `common/public/js/bootstrap-multiselect/` |
+| bootstrap-slider | 2.0.0 | Apache-2.0 | 2012 Stefan Petre | `common/public/js/bootstrap-slider/` |
+| Bootstrap TouchSpin | 4.2.5 | Apache-2.0 | István Ujj-Mészáros | `common/public/js/bootstrap-touchspin/` |
+| KaTeX (CSS + fonts) | - | MIT | KaTeX contributors | `common/public/css/katex.min.css`, `common/public/css/katex/` |
+| Notify.js | - | MIT | 2015 the Notify.js authors | `common/public/js/notify/` |
+| Socket.IO client | - | MIT | Automattic and contributors | served at runtime via `/socket.io/socket.io.js` |
+
+## Own components
+
+The following are **not** third-party and are covered by this project's AGPL
+license:
+
+- `common/public/js/draw2d.js` - draw2d, authored by Andreas Herz. This file is
+  a webpack bundle and embeds its own third-party dependencies (JavaScript
+  Debug by Ben Alman, jQuery contextMenu by Rodney Rehm and others). Those
+  bundled notices are preserved verbatim in the accompanying
+  `common/public/js/draw2d.js.LICENSE.txt`.
+- `common/public/js/toast.js` - project code.
+
+## Corrections
+
+If a component is listed incorrectly, is missing, or an attribution is wrong,
+please open an issue. Attribution errors are treated as bugs.

--- a/author/package.json
+++ b/author/package.json
@@ -2,7 +2,7 @@
   "name": "electra-author",
   "version": "1.0.0",
   "author": "Andreas Herz <a.herz@freegroup.de>",
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "build": "webpack build",
     "watch": "webpack watch",

--- a/brains/package.json
+++ b/brains/package.json
@@ -2,7 +2,7 @@
   "name": "electra-brains",
   "version": "1.0.0",
   "author": "Andreas Herz <a.herz@freegroup.de>",
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "scripts": {},
   "dependencies": {
     "body-parser": "1.20.1",

--- a/common/package.json
+++ b/common/package.json
@@ -4,7 +4,7 @@
     "author": "Andreas Herz <a.herz@freegroup.de>",
     "scripts": {
     },
-    "license": "ISC",
+    "license": "AGPL-3.0-or-later",
       "dependencies": {
         "dotenv": "^16.0.3",
         "express": "^4.18.2",

--- a/designer/package.json
+++ b/designer/package.json
@@ -2,7 +2,7 @@
   "name": "electra-designer",
   "version": "1.0.0",
   "author": "Andreas Herz <a.herz@freegroup.de>",
-  "license": "ISC",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "build": "webpack build",
     "watch": "webpack watch",

--- a/gallery/package.json
+++ b/gallery/package.json
@@ -2,7 +2,7 @@
     "name": "electra-gallery",
     "version": "1.0.0",
     "author": "Andreas Herz <a.herz@freegroup.de>",
-    "license": "MIT",
+    "license": "AGPL-3.0-or-later",
     "scripts": {
         "build": "webpack build",
         "watch": "webpack watch",

--- a/gamification/package.json
+++ b/gamification/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "author": "Andreas Herz <a.herz@freegroup.de>",
     "scripts": {},
-    "license": "MIT",
+    "license": "AGPL-3.0-or-later",
     "dependencies": {
         "body-parser": "^1.20.2",
         "dotenv": "^16.0.3",

--- a/home/package.json
+++ b/home/package.json
@@ -2,7 +2,7 @@
     "name": "electra-home",
     "version": "1.0.0",
     "author": "Andreas Herz <a.herz@freegroup.de>",
-    "license": "ISC",
+    "license": "AGPL-3.0-or-later",
     "scripts": {
         "build": "webpack build",
         "watch": "webpack watch",

--- a/ingress/package.json
+++ b/ingress/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "author": "Andreas Herz <a.herz@freegroup.de>",
     "scripts": {},
-    "license": "ISC",
+    "license": "AGPL-3.0-or-later",
     "dependencies": {
         "body-parser": "^1.20.1",
         "cookie-parser": "^1.4.5",

--- a/legal/package.json
+++ b/legal/package.json
@@ -2,7 +2,7 @@
     "name": "electra-legal",
     "version": "1.0.0",
     "author": "Andreas Herz <a.herz@freegroup.de>",
-    "license": "MIT",
+    "license": "AGPL-3.0-or-later",
     "scripts": {
         "build": "webpack build",
         "watch": "webpack watch",

--- a/permissions/package.json
+++ b/permissions/package.json
@@ -2,7 +2,7 @@
     "name": "electra-permissions",
     "version": "1.0.0",
     "main": "server/index.js",
-    "license": "MIT",
+    "license": "AGPL-3.0-or-later",
     "scripts": {
     },
     "dependencies": {

--- a/shapes/package.json
+++ b/shapes/package.json
@@ -2,7 +2,7 @@
   "name": "electra-shapes",
   "version": "1.0.0",
   "author": "Andreas Herz <a.herz@freegroup.de>",
-  "license": "ISC",
+  "license": "AGPL-3.0-or-later",
   "scripts": {},
   "dependencies": {
     "body-parser": "1.20.1",

--- a/sheets/package.json
+++ b/sheets/package.json
@@ -1,6 +1,7 @@
 {
   "name": "electra-sheets",
   "version": "1.0.0",
+  "license": "AGPL-3.0-or-later",
   "author": "Andreas Herz <a.herz@freegroup.de>",
   "scripts": {},
   "dependencies": {

--- a/simulator/package.json
+++ b/simulator/package.json
@@ -2,7 +2,7 @@
   "name": "electra-simulator",
   "version": "1.0.0",
   "author": "Andreas Herz <a.herz@freegroup.de>",
-  "license": "ISC",
+  "license": "AGPL-3.0-or-later",
   "scripts": {
     "build": "webpack build",
     "watch": "webpack watch",

--- a/userinfo/package.json
+++ b/userinfo/package.json
@@ -4,7 +4,7 @@
     "author": "Andreas Herz <a.herz@freegroup.de>",
     "scripts": {
     },
-    "license": "ISC",
+    "license": "AGPL-3.0-or-later",
       "dependencies": {
       "dotenv": "^16.0.3",
       "express": "^4.18.2",


### PR DESCRIPTION
Settles the licensing of the project. Until now there was **no LICENSE file at all**, while the 15 `package.json` declared MIT or ISC.

## Why AGPL and not a NonCommercial license

The original plan was CC BY-NC-SA. Checking it turned up a hard blocker: openCoDE and comparable public-sector directories require OSI-conformant licenses and keep NC clauses on an explicit negative list. Their stated reason is exactly the problem - nobody can safely answer whether a school with tuition fees or an authority with a fee-funded budget is still "non-commercial". An NC license would have locked the project out of the very channels through which German schools find software.

AGPL-3.0 keeps use free for everyone with no commercial/non-commercial line to draw, and its section 13 addresses the actual concern: anyone running a modified version as a network service has to publish the corresponding source.

## Contents

| File | Purpose |
|---|---|
| `LICENSE` | AGPL-3.0, verbatim and unmodified |
| `LICENSING.md` | plain-language summary, DE (authoritative) + EN |
| `COMMERCIAL-LICENSE.md` | dual licensing; services need no license |
| `THIRD-PARTY-NOTICES.md` | 9 vendored libraries, all permissive and one-way compatible with AGPL |
| `CLA.md` | contributor agreement, DE + EN |
| `CONTRIBUTING.md` | separates DCO (origin) from CLA (rights) |
| `.github/workflows/cla.yml` | enforces signing, signatures stay in this repo |

Plus `AGPL-3.0-or-later` as the SPDX identifier in all 14 `package.json` on this branch.

## On the CLA

It grants an **exclusive right of use** under sec. 31 UrhG instead of assigning copyright, because sec. 29(1) UrhG forbids transferring copyright under German law. Section 3a carries advance consent to a later license change, so relicensing never requires chasing down every past contributor. Contributors keep a non-exclusive right to their own code, so signing does not cost them the use of their own patch.

## After merging

The CLA check only blocks merges once it is added as a **required status check** in the branch protection rule for `main` - and it can only be added there after the workflow has run at least once.